### PR TITLE
fix: keep guides visible without blocking page clicks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ dist/
 .turbo/
 .vite/
 coverage/
+test-results/
+playwright-report/
 *.log
 pnpm-debug.log*
 npm-debug.log*

--- a/apps/extension/src/content.tsx
+++ b/apps/extension/src/content.tsx
@@ -40,6 +40,10 @@ const getOrCreateContainer = () => {
     document.body.appendChild(host);
   }
 
+  // Keep the full-viewport extension shell transparent. Interactive children
+  // such as the active tool overlay and toolbar opt back into pointer events.
+  host.style.pointerEvents = "none";
+
   const shadowRoot = host.shadowRoot ?? host.attachShadow({ mode: "open" });
 
   let container = shadowRoot.getElementById(ROOT_ID);

--- a/apps/site/e2e/fixtures/guide-overlay.html
+++ b/apps/site/e2e/fixtures/guide-overlay.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Guide overlay regression fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/e2e/fixtures/guide-overlay.tsx"></script>
+  </body>
+</html>

--- a/apps/site/e2e/fixtures/guide-overlay.tsx
+++ b/apps/site/e2e/fixtures/guide-overlay.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+
+function Fixture() {
+  const [clicks, setClicks] = useState(0);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setClicks((value) => value + 1)}
+        style={{
+          position: "absolute",
+          left: 240,
+          top: 240,
+          width: 200,
+          height: 100,
+        }}
+      >
+        Underlying app button
+      </button>
+      <output data-testid="underlying-click-count">{clicks}</output>
+    </>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(<Fixture />);
+await import("../../../extension/src/content");

--- a/apps/site/e2e/guide-mode-transition.spec.ts
+++ b/apps/site/e2e/guide-mode-transition.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+
+test("leaving guides does not reveal a stale element hover", async ({ page }) => {
+  await page.goto("/e2e/fixtures/guide-overlay.html");
+
+  const host = page.locator("#mesurer-extension-host");
+  const overlay = host.locator(".mesurer-root > div").first();
+  const guidesButton = page.getByRole("button", { name: "Guides (G)" });
+
+  await guidesButton.click();
+  await page.mouse.move(300, 280);
+  await page.waitForTimeout(50);
+  await page.keyboard.press("g");
+
+  await expect(overlay).toHaveCSS("pointer-events", "none");
+  await expect(
+    overlay.locator('div[style*="width: 200px"][style*="height: 100px"]'),
+  ).toHaveCount(0);
+});

--- a/apps/site/e2e/guide-overlay.spec.ts
+++ b/apps/site/e2e/guide-overlay.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+test("placed guides remain visible while host-app clicks pass through", async ({
+  page,
+}) => {
+  await page.goto("/e2e/fixtures/guide-overlay.html");
+
+  const guidesButton = page.getByRole("button", { name: "Guides (G)" });
+  const underlyingButton = page.getByRole("button", {
+    name: "Underlying app button",
+  });
+  const extensionHost = page.locator("#mesurer-extension-host");
+  const overlay = extensionHost.locator(".mesurer-root > div").first();
+
+  await expect(guidesButton).toBeVisible();
+  await guidesButton.click();
+  await expect(overlay).toHaveCSS("pointer-events", "auto");
+
+  await page.mouse.click(300, 200);
+  await page.mouse.click(150, 250);
+  await page.keyboard.press("g");
+
+  await expect(overlay).toHaveCSS("pointer-events", "none");
+  await expect(overlay).toHaveCSS("opacity", "1");
+  await expect(overlay.locator(":scope > div")).toHaveCount(2);
+  await expect(extensionHost).toHaveCSS("pointer-events", "none");
+
+  const box = await underlyingButton.boundingBox();
+  expect(box).not.toBeNull();
+  await page.mouse.click(300, box!.y + box!.height / 2);
+  await expect(page.getByTestId("underlying-click-count")).toHaveText("1");
+
+  await guidesButton.click();
+  await expect(overlay).toHaveCSS("pointer-events", "auto");
+});

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "pnpm --filter mesurer build && vite build",
     "deploy:pages": "npx wrangler pages deploy dist --project-name mesurer",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "playwright test"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",
@@ -15,6 +16,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/vite": "^4.2.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/apps/site/playwright.config.ts
+++ b/apps/site/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 10_000,
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    headless: true,
+  },
+  webServer: {
+    command:
+      "pnpm --dir ../../packages/mesurer build && pnpm exec vite --host 127.0.0.1 --port 4173",
+    url: "http://127.0.0.1:4173/e2e/fixtures/guide-overlay.html",
+    reuseExistingServer: true,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: devices["Desktop Chrome"],
+    },
+  ],
+});

--- a/packages/mesurer/render/measurer-overlay.tsx
+++ b/packages/mesurer/render/measurer-overlay.tsx
@@ -126,6 +126,7 @@ export const MeasurerOverlay = memo(function MeasurerOverlay({
   const overlayVisible = enabled;
   const overlayInteractive =
     overlayVisible && toolMode !== "none" && toolMode !== "text-inspector";
+  const selectionVisible = toolMode === "select";
 
   return (
     <div
@@ -146,7 +147,7 @@ export const MeasurerOverlay = memo(function MeasurerOverlay({
       onPointerUp={onPointerUp}
       onPointerLeave={onPointerLeave}
     >
-      {!guidesEnabled
+      {selectionVisible
         ? displayedMeasurements.map((measurement, index) => (
             <MeasurementBox
               key={measurement.id}
@@ -158,7 +159,7 @@ export const MeasurerOverlay = memo(function MeasurerOverlay({
           ))
         : null}
 
-      {!guidesEnabled && activeRect && isDragging ? (
+      {selectionVisible && activeRect && isDragging ? (
         <>
           <div
             className="msr:pointer-events-none msr:absolute"
@@ -199,7 +200,7 @@ export const MeasurerOverlay = memo(function MeasurerOverlay({
         </>
       ) : null}
 
-      {!guidesEnabled && hoverRectToShow ? (
+      {selectionVisible && hoverRectToShow ? (
         <div
           className="msr:pointer-events-none msr:absolute"
           style={{
@@ -279,7 +280,7 @@ export const MeasurerOverlay = memo(function MeasurerOverlay({
         </div>
       ) : null}
 
-      {!guidesEnabled
+      {selectionVisible
         ? displayedSelectedMeasurements.map((measurement, index) => (
             <SelectedMeasurementBox
               key={measurement.id}
@@ -300,7 +301,7 @@ export const MeasurerOverlay = memo(function MeasurerOverlay({
         />
       ))}
 
-      {!guidesEnabled && altPressed && optionPairOverlay ? (
+      {selectionVisible && altPressed && optionPairOverlay ? (
         <DistanceOverlayItem
           key={`option-${optionPairOverlay.id}`}
           distance={optionPairOverlay}
@@ -316,7 +317,7 @@ export const MeasurerOverlay = memo(function MeasurerOverlay({
         />
       ) : null}
 
-      {!guidesEnabled && altPressed && optionContainerLines ? (
+      {selectionVisible && altPressed && optionContainerLines ? (
         <>
           {optionContainerLines.top.value > 0 ? (
             <>

--- a/packages/mesurer/render/measurer-overlay.tsx
+++ b/packages/mesurer/render/measurer-overlay.tsx
@@ -123,8 +123,9 @@ export const MeasurerOverlay = memo(function MeasurerOverlay({
   onGuidePointerUp,
   onGuidePointerCancel,
 }: MeasurerOverlayProps) {
-  const overlayVisible = enabled && toolMode !== "none";
-  const overlayInteractive = overlayVisible && toolMode !== "text-inspector";
+  const overlayVisible = enabled;
+  const overlayInteractive =
+    overlayVisible && toolMode !== "none" && toolMode !== "text-inspector";
 
   return (
     <div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@5.4.21(lightningcss@1.32.0))
@@ -590,6 +593,11 @@ packages:
       react: '>= 16.8'
       react-dom: '>= 16.8'
 
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -968,6 +976,11 @@ packages:
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1144,6 +1157,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -1653,6 +1676,10 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
@@ -1981,6 +2008,9 @@ snapshots:
       mlly: 1.8.2
       rollup: 4.60.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2105,6 +2135,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8):
     dependencies:


### PR DESCRIPTION
## Summary
- decouple overlay visibility from active interaction mode so guides remain visible after leaving Guides mode
- make the Chrome extension's full-viewport shadow host pointer-transparent by default
- add a Playwright regression test covering multiple guides, passive guide visibility, guide-line click-through, and re-entering Guides mode

## User flow
1. Press **G** and place one or more guides.
2. Press **G** again to leave guide editing.
3. Guides stay visible while clicks reach the underlying application.
4. Press **G** to edit guides again, or **M** to hide Mesurer.

## Verification
- `pnpm --filter mesurer-site test -- e2e/guide-overlay.spec.ts`
- `pnpm --dir packages/mesurer typecheck`
- `pnpm exec tsc --noEmit -p tsconfig.json` in `apps/extension` and `apps/site`
- extension and site production builds