### PR TITLE
fix(site): restore One Dollar Stats analytics script

### DIFF
--- a/apps/site/index.html
+++ b/apps/site/index.html
@@ -29,6 +29,11 @@
     <meta name="twitter:image" content="https://mesurer.dev/x-og.png" />
     <meta name="twitter:image:alt" content="Mesurer preview image" />
 
+    <script
+      defer
+      src="https://assets.onedollarstats.com/stonks.js"
+    ></script>
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The One Dollar Stats (`stonks.js`) snippet was accidentally removed from `apps/site/index.html` in commit `e20a2f1` ("feat: various improvements"). That commit only intended to update meta descriptions, but the analytics `<script>` tag was dropped at the same time.

As a result, the live site at mesurer.dev no longer loads the analytics script.

## Fix

Restore the original CDN snippet in `index.html`:

```html
<script
  defer
  src="https://assets.onedollarstats.com/stonks.js"
></script>
```

## Verification

- Dev server serves the script tag in HTML
- Production build (`vite build`) includes the script in `dist/index.html`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1bde8ca-48a4-490d-9165-25d67848fd35?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1bde8ca-48a4-490d-9165-25d67848fd35&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

