### PR TITLE
ci(site): build site on PRs that touch site files

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,0 +1,34 @@
+name: Build Site
+
+on:
+  pull_request:
+    paths:
+      - "apps/site/**"
+      - "packages/mesurer/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/build-site.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/site/**"
+      - "packages/mesurer/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/build-site.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build:site

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --force",
-    "build": "pnpm --filter mesurer build && vite build",
+    "build": "pnpm --dir ../../packages/mesurer build && vite build",
     "deploy:pages": "npx wrangler pages deploy dist --project-name mesurer-site",
     "preview": "vite preview",
     "test": "playwright test"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a simple CI workflow that runs `pnpm build:site` on PRs (and `main` pushes) when site-related files change.

No API tokens or deploy steps — Cloudflare Pages already handles deployment from Git.

## Also fixes

The site build script used `pnpm --filter mesurer build`, which matched the root workspace package and caused an infinite build loop. Switched to `pnpm --dir ../../packages/mesurer build` so `pnpm build:site` works reliably.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1bde8ca-48a4-490d-9165-25d67848fd35?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1bde8ca-48a4-490d-9165-25d67848fd35&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

