### PR TITLE
Add Feedback link to footer

### DIFF
--- a/apps/site/src/app.tsx
+++ b/apps/site/src/app.tsx
@@ -501,14 +501,21 @@ export function App() {
           <HomeContent />
         )}
         {!isDocsPage && (
-          <div className="pt-6 text-muted">
+          <div className="flex gap-4 pt-6 text-muted">
             <a
               href="/changelog"
               className="transition-colors hover:text-strong"
             >
               Changelog
             </a>
-            <span className="px-2">·</span>
+            <a
+              href="https://github.com/ibelick/mesurer/issues/new?title=Feedback&body=**What%20happened%3F**%0A%0A%0A**What%20would%20help%3F**%0A%0A%0A**Context**%20%28browser%2C%20URL%29%0A"
+              target="_blank"
+              rel="noreferrer"
+              className="transition-colors hover:text-strong"
+            >
+              Feedback
+            </a>
             <a href="/privacy" className="transition-colors hover:text-strong">
               Privacy
             </a>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Remove the `·` separator between footer links
- Add a **Feedback** link before **Privacy** that opens a pre-filled GitHub issue

## Footer layout

`Changelog` · `Feedback` · `Privacy` → `Changelog` `Feedback` `Privacy` (spaced with flex gap)

## Feedback issue template

The link opens a new GitHub issue titled "Feedback" with:

- **What happened?**
- **What would help?**
- **Context** (browser, URL)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3420c37d-7715-4d8b-82b5-05f3a33e7720?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3420c37d-7715-4d8b-82b5-05f3a33e7720&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

