### PR TITLE
feat: pin option measurements with option+s

### DIFF
--- a/packages/mesurer/README.md
+++ b/packages/mesurer/README.md
@@ -94,6 +94,7 @@ Props are the defaults. Saved settings override them; **Use defaults** restores 
 | `H`                    | Set guide orientation to horizontal.                  |
 | `V`                    | Set guide orientation to vertical.                    |
 | `Alt`                  | Temporarily enable option/guide measurement overlays. |
+| `Alt + S`              | Pin the measurement currently shown under `Alt` so it stays on screen. |
 | `Esc`                  | Close an open panel, cancel the current interaction, or deselect the tool. Press again to minimize Mesurer. |
 | `Backspace` / `Delete` | Remove selected guides, arrows, pen strokes, or text. |
 | `Cmd/Ctrl + Z`         | Undo.                                                 |

--- a/packages/mesurer/components/measure-tag.tsx
+++ b/packages/mesurer/components/measure-tag.tsx
@@ -1,26 +1,37 @@
 "use client"
 
-import type { CSSProperties, ReactNode } from "react"
+import type { CSSProperties, PointerEventHandler, ReactNode } from "react"
 import { cn } from "../core/utils"
 
 type MeasureTagProps = {
   children: ReactNode
   className?: string
   style?: CSSProperties
+  interactive?: boolean
+  onPointerEnter?: PointerEventHandler<HTMLDivElement>
+  onPointerDown?: PointerEventHandler<HTMLDivElement>
 }
 
 export function MeasureTag({
   children,
   className = "",
   style,
+  interactive = false,
+  onPointerEnter,
+  onPointerDown,
 }: MeasureTagProps) {
   return (
     <div
       className={cn(
-        "msr:pointer-events-none msr:absolute msr:rounded msr:px-1 msr:py-0.5 msr:text-[10px] msr:text-ink-50 msr:tabular-nums msr:select-none",
+        interactive
+          ? "msr:pointer-events-auto msr:cursor-pointer"
+          : "msr:pointer-events-none",
+        "msr:absolute msr:rounded msr:px-1 msr:py-0.5 msr:text-[10px] msr:text-ink-50 msr:tabular-nums msr:select-none",
         className
       )}
       style={style}
+      onPointerEnter={onPointerEnter}
+      onPointerDown={onPointerDown}
     >
       {children}
     </div>

--- a/packages/mesurer/core/distances.ts
+++ b/packages/mesurer/core/distances.ts
@@ -1,11 +1,109 @@
+import { getRectFromDom } from "./dom"
 import {
   clamp,
   denormalizeRect,
   getViewportSize,
   normalizeRect,
+  rectContainsPoint,
 } from "./geometry"
-import type { DistanceOverlay, Rect } from "./types"
+import { getElementBetweenGuides } from "./guides"
+import type { DistanceOverlay, Point, Rect } from "./types"
 import { createId } from "./utils"
+
+export const isElementRect = (rect: Rect) => rect.width >= 1 && rect.height >= 1
+
+export const getPinnedLabelPoint = (distance: DistanceOverlay): Point | null => {
+  if (distance.pinTargetRect && distance.pinCursorOffset) {
+    return {
+      x: distance.pinTargetRect.left + distance.pinCursorOffset.x,
+      y: distance.pinTargetRect.top + distance.pinCursorOffset.y,
+    }
+  }
+  return distance.pinCursor ?? null
+}
+
+export const applyPinCursor = (distance: DistanceOverlay): DistanceOverlay => {
+  const point = getPinnedLabelPoint(distance)
+  if (!point) return distance
+  return {
+    ...distance,
+    horizontal: distance.horizontal
+      ? { ...distance.horizontal, y: point.y }
+      : null,
+    vertical: distance.vertical
+      ? { ...distance.vertical, x: point.x }
+      : null,
+  }
+}
+
+export const withPin = (
+  updated: DistanceOverlay,
+  source: DistanceOverlay,
+): DistanceOverlay =>
+  applyPinCursor({
+    ...updated,
+    id: source.id,
+    pinTargetRef: source.pinTargetRef,
+    pinTargetRect: source.pinTargetRect,
+    pinCursor: source.pinCursor,
+    pinCursorOffset: source.pinCursorOffset,
+  })
+
+export const attachPinnedGuideTarget = (params: {
+  distance: DistanceOverlay
+  document: Document
+  overlayNode: HTMLElement | null
+  pointer: Point | null
+}): DistanceOverlay => {
+  const { distance, pointer } = params
+  const candidates = [
+    isElementRect(distance.rectA)
+      ? { ref: distance.elementRefA, rect: distance.rectA }
+      : null,
+    isElementRect(distance.rectB)
+      ? { ref: distance.elementRefB, rect: distance.rectB }
+      : null,
+  ].filter((candidate) => candidate !== null)
+
+  let pinTargetRef: Element | undefined
+
+  if (candidates.length > 0) {
+    const underPointer = pointer
+      ? candidates.find((candidate) => rectContainsPoint(candidate.rect, pointer))
+      : undefined
+    pinTargetRef =
+      (underPointer ?? candidates[candidates.length - 1]).ref ?? undefined
+  } else if (pointer) {
+    // Both sides are guides: pin to the element the pair wraps under the cursor.
+    const verticalGuides = distance.rectA.width < 1 && distance.rectB.width < 1
+    const horizontalGuides = distance.rectA.height < 1 && distance.rectB.height < 1
+    if (verticalGuides || horizontalGuides) {
+      pinTargetRef =
+        getElementBetweenGuides({
+          document: params.document,
+          overlayNode: params.overlayNode,
+          orientation: verticalGuides ? "vertical" : "horizontal",
+          start: verticalGuides ? distance.rectA.left : distance.rectA.top,
+          end: verticalGuides ? distance.rectB.left : distance.rectB.top,
+          pointer,
+        }) ?? undefined
+    }
+  }
+
+  const pinTargetRect = pinTargetRef ? getRectFromDom(pinTargetRef) : undefined
+
+  return applyPinCursor({
+    ...distance,
+    id: createId(),
+    pinTargetRef,
+    pinTargetRect,
+    pinCursor: pointer ?? undefined,
+    pinCursorOffset:
+      pointer && pinTargetRect
+        ? { x: pointer.x - pinTargetRect.left, y: pointer.y - pinTargetRect.top }
+        : undefined,
+  })
+}
 
 export const getDistanceOverlay = (
   rectA: Rect,
@@ -122,8 +220,5 @@ export const updateDistanceForResize = (
     ownerWindow
   )
 
-  return {
-    ...updated,
-    id: distance.id,
-  }
+  return withPin(updated, distance)
 }

--- a/packages/mesurer/core/geometry.ts
+++ b/packages/mesurer/core/geometry.ts
@@ -54,6 +54,12 @@ export const intersectionArea = (rectA: Rect, rectB: Rect) => {
   return width * height
 }
 
+export const rectContainsPoint = (rect: Rect, point: Point) =>
+  point.x >= rect.left &&
+  point.x <= rect.left + rect.width &&
+  point.y >= rect.top &&
+  point.y <= rect.top + rect.height
+
 export const rectAlmostEqual = (a: Rect, b: Rect, epsilon = 0.25) =>
   Math.abs(a.left - b.left) < epsilon &&
   Math.abs(a.top - b.top) < epsilon &&

--- a/packages/mesurer/core/guides.ts
+++ b/packages/mesurer/core/guides.ts
@@ -1,6 +1,6 @@
 import { GUIDE_SNAP_DISTANCE, MIN_SINGLE_TARGET_SIZE } from "./constants"
 import { getBodyElementsCached, getRectFromDomCached } from "./dom"
-import { getViewportSize } from "./geometry"
+import { getViewportSize, rectContainsPoint } from "./geometry"
 import type { Guide, Point, Rect } from "./types"
 
 export const getGuideRect = (guide: Guide, ownerWindow: Window = window): Rect => {
@@ -138,6 +138,58 @@ export const getNearestElementToGuide = (params: {
       bestDistance = distance
       bestArea = area
       bestElement = element
+    }
+  }
+
+  return bestElement
+}
+
+export const getElementBetweenGuides = (params: {
+  document: Document
+  overlayNode: HTMLElement | null
+  orientation: Guide["orientation"]
+  start: number
+  end: number
+  pointer: Point
+}) => {
+  const min = Math.min(params.start, params.end)
+  const max = Math.max(params.start, params.end)
+  if (max - min < 1) return null
+
+  const ownerDocument = params.document
+  const overlayNode = params.overlayNode
+  const elements = getBodyElementsCached(ownerDocument)
+  const ElementConstructor = ownerDocument.defaultView?.HTMLElement ?? HTMLElement
+  let bestElement: Element | null = null
+  let bestArea = Number.POSITIVE_INFINITY
+
+  for (const element of elements) {
+    if (!(element instanceof ElementConstructor)) continue
+    if (overlayNode && (overlayNode === element || overlayNode.contains(element))) {
+      continue
+    }
+    if (element === ownerDocument.body || element === ownerDocument.documentElement) {
+      continue
+    }
+    const rect = getRectFromDomCached(element)
+    if (
+      rect.width < MIN_SINGLE_TARGET_SIZE ||
+      rect.height < MIN_SINGLE_TARGET_SIZE
+    ) {
+      continue
+    }
+    if (!rectContainsPoint(rect, params.pointer)) continue
+
+    const overlap =
+      params.orientation === "vertical"
+        ? Math.min(rect.left + rect.width, max) - Math.max(rect.left, min)
+        : Math.min(rect.top + rect.height, max) - Math.max(rect.top, min)
+    if (overlap <= 0) continue
+
+    const area = rect.width * rect.height
+    if (area < bestArea) {
+      bestElement = element
+      bestArea = area
     }
   }
 

--- a/packages/mesurer/core/types.ts
+++ b/packages/mesurer/core/types.ts
@@ -95,6 +95,10 @@ export type DistanceOverlay = {
   normalizedRectB: NormalizedRect
   elementRefA?: Element | null
   elementRefB?: Element | null
+  pinTargetRef?: Element | null
+  pinTargetRect?: Rect | null
+  pinCursor?: Point | null
+  pinCursorOffset?: Point | null
   horizontal: {
     x1: number
     x2: number

--- a/packages/mesurer/core/workspace.ts
+++ b/packages/mesurer/core/workspace.ts
@@ -14,6 +14,7 @@ export const stripDistance = (distance: DistanceOverlay): DistanceOverlay => ({
   ...distance,
   elementRefA: undefined,
   elementRefB: undefined,
+  pinTargetRef: undefined,
 })
 
 export const getTabId = (ownerWindow: Window) => {

--- a/packages/mesurer/hooks/use-hotkeys.ts
+++ b/packages/mesurer/hooks/use-hotkeys.ts
@@ -76,6 +76,7 @@ type HotkeyOptions = {
   setXrayVisible: Dispatch<SetStateAction<boolean>>
   setRulersVisible: Dispatch<SetStateAction<boolean>>
   setAltPressed: Dispatch<SetStateAction<boolean>>
+  pinDistance: () => boolean
   isOverlayActive: () => boolean
   setGuideOrientation: Dispatch<SetStateAction<"vertical" | "horizontal">>
   onInteract: () => void
@@ -236,7 +237,17 @@ export const useHotkeys = (options: HotkeyOptions) => {
 
       const key = event.key.toLowerCase()
       const toolGroupShortcut = getMesurerToolGroupShortcut(event)
-      if (event.altKey) return
+      if (event.key === "Alt") {
+        current.setAltPressed(true)
+      }
+      if (event.altKey) {
+        // Option+S pins the distance currently previewed under Option.
+        // Matched on `code`: macOS reports event.key as "ß" while Option is held.
+        if (event.code === "KeyS" && current.pinDistance()) {
+          event.preventDefault()
+        }
+        return
+      }
 
       if (key === "p") {
         event.preventDefault()
@@ -302,10 +313,6 @@ export const useHotkeys = (options: HotkeyOptions) => {
           current.setGuideOrientation("vertical")
           current.onInteract()
         }
-      }
-
-      if (event.key === "Alt") {
-        current.setAltPressed(true)
       }
 
       if (event.key === "Backspace" || event.key === "Delete") {

--- a/packages/mesurer/hooks/use-interaction-lifecycle.ts
+++ b/packages/mesurer/hooks/use-interaction-lifecycle.ts
@@ -58,6 +58,7 @@ type Options = {
   setArrowPreviewEnd: Dispatch<SetStateAction<Point | null>>;
   setXrayVisible: Dispatch<SetStateAction<boolean>>;
   setAltPressed: Dispatch<SetStateAction<boolean>>;
+  pinDistance: () => boolean;
   setToolMode: (mode: ToolMode) => void;
   clearSelectionRect: () => void;
   clearGuideDragHold: () => void;
@@ -238,6 +239,7 @@ export const useInteractionLifecycle = (options: Options) => {
     setXrayVisible: options.setXrayVisible,
     setRulersVisible: options.setRulersVisible,
     setAltPressed: options.setAltPressed,
+    pinDistance: options.pinDistance,
     isOverlayActive: () => overlayActive,
     setGuideOrientation: options.setGuideOrientation,
     onInteract: options.onInteract,

--- a/packages/mesurer/hooks/use-live-element-tracking.ts
+++ b/packages/mesurer/hooks/use-live-element-tracking.ts
@@ -1,6 +1,6 @@
 import type { Dispatch, RefObject, SetStateAction } from "react"
 import { useLayoutEffect, useRef } from "react"
-import { getDistanceOverlay } from "../core/distances"
+import { applyPinCursor, getDistanceOverlay, withPin } from "../core/distances"
 import { getInspectMeasurement, getRectFromDom } from "../core/dom"
 import { normalizeRect, rectAlmostEqual } from "../core/geometry"
 import type {
@@ -82,11 +82,29 @@ export const useLiveElementTracking = (params: LiveParams) => {
       current.setHeldDistances((prev) => {
         let changed = false
         const next = prev.map((distance) => {
+          let nextDistance = distance
+          if (
+            distance.pinTargetRef &&
+            current.document.contains(distance.pinTargetRef)
+          ) {
+            const pinTargetRect = getRectFromDom(distance.pinTargetRef)
+            if (
+              !distance.pinTargetRect ||
+              !rectAlmostEqual(pinTargetRect, distance.pinTargetRect)
+            ) {
+              nextDistance = applyPinCursor({
+                ...nextDistance,
+                pinTargetRect,
+              })
+              changed = true
+            }
+          }
+
           const canTrackA =
             distance.elementRefA && current.document.contains(distance.elementRefA)
           const canTrackB =
             distance.elementRefB && current.document.contains(distance.elementRefB)
-          if (!canTrackA && !canTrackB) return distance
+          if (!canTrackA && !canTrackB) return nextDistance
 
           const rectA = canTrackA
             ? getRectFromDom(distance.elementRefA!)
@@ -95,10 +113,10 @@ export const useLiveElementTracking = (params: LiveParams) => {
             ? getRectFromDom(distance.elementRefB!)
             : distance.rectB
           if (
-            rectAlmostEqual(rectA, distance.rectA) &&
-            rectAlmostEqual(rectB, distance.rectB)
+            rectAlmostEqual(rectA, nextDistance.rectA) &&
+            rectAlmostEqual(rectB, nextDistance.rectB)
           ) {
-            return distance
+            return nextDistance
           }
 
           const updated = getDistanceOverlay(
@@ -110,10 +128,7 @@ export const useLiveElementTracking = (params: LiveParams) => {
           )
 
           changed = true
-          return {
-            ...updated,
-            id: distance.id,
-          }
+          return withPin(updated, nextDistance)
         })
         return changed || prev.length === 0 ? next : prev
       })

--- a/packages/mesurer/hooks/use-mesurer-pointer.ts
+++ b/packages/mesurer/hooks/use-mesurer-pointer.ts
@@ -187,7 +187,7 @@ export const useMesurerPointer = ({
       const point = { x: event.clientX, y: event.clientY }
       selection.preparePointerDown(point, event.shiftKey)
 
-      if (altPressed && optionPairOverlay) {
+      if (!guidesEnabled && altPressed && optionPairOverlay) {
         commit()
         setHeldDistances((prev) => [
           ...prev,
@@ -234,7 +234,7 @@ export const useMesurerPointer = ({
       altPressed,
       clearSelectionRect,
       createActionCommit,
-          draggingGuideId,
+      draggingGuideId,
       document,
       enabled,
       settingsOpen,

--- a/packages/mesurer/mesurer-client.tsx
+++ b/packages/mesurer/mesurer-client.tsx
@@ -37,6 +37,7 @@ import { useXray } from "./hooks/use-xray";
 import { useArrowsPointer } from "./hooks/use-arrows-pointer";
 import { usePenPointer } from "./hooks/use-pen-pointer";
 import { getRectFromPoints } from "./core/geometry";
+import { attachPinnedGuideTarget } from "./core/distances";
 import { useAnnotationSelection } from "./hooks/use-annotation-selection";
 import { useAnnotationCallbacks } from "./hooks/use-annotation-callbacks";
 import type { ColorPickerFormat } from "./core/colors";
@@ -927,6 +928,29 @@ export function MesurerClient({
   const activateToolbar = useCallback(() => {
     setToolbarActive(true);
   }, [setToolbarActive]);
+  const pinableOverlay = guidesEnabled
+    ? (guideDistanceOverlay ?? optionPairOverlay)
+    : (optionPairOverlay ?? guideDistanceOverlay);
+  const pinDistance = useCallback(() => {
+    if (!pinableOverlay) return false;
+    recordSnapshot();
+    setHeldDistancesPersisted((prev) => [
+      ...prev,
+      attachPinnedGuideTarget({
+        distance: pinableOverlay,
+        document: ownerDocument,
+        overlayNode: overlayRef.current,
+        pointer: hoverPointer,
+      }),
+    ]);
+    return true;
+  }, [
+    hoverPointer,
+    ownerDocument,
+    pinableOverlay,
+    recordSnapshot,
+    setHeldDistancesPersisted,
+  ]);
   const restoreToolbar = useCallback(() => {
     setMinimized(false);
     setToolbarActive(true);
@@ -981,6 +1005,7 @@ export function MesurerClient({
     setArrowPreviewEnd,
     setXrayVisible,
     setAltPressed,
+    pinDistance,
     setToolMode,
     clearSelectionRect,
     clearGuideDragHold,

--- a/packages/mesurer/render/distance-overlay-item.tsx
+++ b/packages/mesurer/render/distance-overlay-item.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useRef, type PointerEvent } from "react";
 import { MeasureTag } from "../components/measure-tag";
+import { getPinnedLabelPoint, isElementRect } from "../core/distances";
 import type { DistanceOverlay } from "../core/types";
 import { formatValue } from "../core/utils";
 
@@ -16,23 +17,28 @@ export const DistanceOverlayItem = memo(function DistanceOverlayItem({
   labelOffset,
   onRemove,
 }: DistanceOverlayItemProps) {
-  const showRectA = distance.rectA.width >= 1 && distance.rectA.height >= 1;
-  const showRectB = distance.rectB.width >= 1 && distance.rectB.height >= 1;
+  const showRectA = isElementRect(distance.rectA);
+  const showRectB = isElementRect(distance.rectB);
+  const pinPoint = getPinnedLabelPoint(distance);
+  // A pin is created under a stationary cursor, so it only becomes removable
+  // once the pointer has actually moved onto its label. Without this the click
+  // that places the next guide would land on the fresh label and delete it.
+  const armedRef = useRef(false);
+  const arm = onRemove
+    ? () => {
+        armedRef.current = true;
+      }
+    : undefined;
+  const handleRemove = onRemove
+    ? (event: PointerEvent<HTMLDivElement>) => {
+        if (event.button !== 0 || !armedRef.current) return;
+        event.stopPropagation();
+        onRemove(distance.id);
+      }
+    : undefined;
 
   return (
-    <div
-      className={
-        onRemove ? "msr:pointer-events-auto" : "msr:pointer-events-none"
-      }
-      onClick={
-        onRemove
-          ? (event) => {
-              event.stopPropagation();
-              onRemove(distance.id);
-            }
-          : undefined
-      }
-    >
+    <div className="msr:pointer-events-none">
       {showRectA ? (
         <div
           className="msr:absolute msr:rounded msr:border msr:border-[#2563eb]/70"
@@ -90,10 +96,15 @@ export const DistanceOverlayItem = memo(function DistanceOverlayItem({
           />
           <MeasureTag
             className="msr:-translate-x-1/2 msr:bg-ink-900/90"
+            interactive={Boolean(onRemove)}
             style={{
-              left: (distance.horizontal.x1 + distance.horizontal.x2) / 2,
+              left:
+                pinPoint?.x ??
+                (distance.horizontal.x1 + distance.horizontal.x2) / 2,
               top: distance.horizontal.y + labelOffset,
             }}
+            onPointerEnter={arm}
+            onPointerDown={handleRemove}
           >
             {formatValue(distance.horizontal.value)}
           </MeasureTag>
@@ -111,10 +122,15 @@ export const DistanceOverlayItem = memo(function DistanceOverlayItem({
           />
           <MeasureTag
             className="msr:-translate-y-1/2 msr:bg-ink-900/90"
+            interactive={Boolean(onRemove)}
             style={{
               left: distance.vertical.x + labelOffset,
-              top: (distance.vertical.y1 + distance.vertical.y2) / 2,
+              top:
+                pinPoint?.y ??
+                (distance.vertical.y1 + distance.vertical.y2) / 2,
             }}
+            onPointerEnter={arm}
+            onPointerDown={handleRemove}
           >
             {formatValue(distance.vertical.value)}
           </MeasureTag>


### PR DESCRIPTION
Option-hover measurements disappear when Option is released, so there was no way to keep a spacing on screen while looking elsewhere. Option+S now pins the measurement currently previewed under Option; Option on its own behaves exactly as before and still saves nothing.

The pin lands at the cursor rather than at the midpoint of the span, so pins stay readable on a page full of guides. When the cursor is over an element the measured pair wraps, the pin attaches to that element and tracks it through scroll, resize, and layout changes.

- core/distances.ts: attachPinnedGuideTarget resolves the pin target - the element under the cursor when either side is an element, otherwise the element the two guides span. pinTargetRect is always derived from the chosen ref, so ref and rect cannot disagree. pinCursorOffset keeps the label glued to the element instead of the viewport, and withPin carries the pin fields across every overlay rebuild.
- core/guides.ts: getElementBetweenGuides picks the smallest element that contains the pointer and overlaps the guide gap.
- use-live-element-tracking.ts: the existing rAF loop is the single place pin geometry is refreshed.
- use-hotkeys.ts: setAltPressed moved above the altKey early return so the preview is live before S arrives; matched on event.code because macOS reports event.key as "ß" while Option is held.
- distance-overlay-item.tsx: a pin becomes removable only once the pointer has entered its label, so the click that places the next guide no longer deletes a freshly created pin or gets swallowed.
- measure-tag.tsx: new interactive prop swapping pointer-events-none for pointer-events-auto/cursor-pointer.
- geometry.ts: shared rectContainsPoint helper.

Alt+click no longer holds a distance while the guide tool is active - that path was eating the guide click. Pins survive a workspace reload but lose live element tracking, since stripDistance cannot serialize the ref.



https://github.com/user-attachments/assets/4db72f3f-cc27-4551-9e8b-6704f3e65379
